### PR TITLE
Explicitly changing ftype to fix issue

### DIFF
--- a/panns/index.py
+++ b/panns/index.py
@@ -167,7 +167,7 @@ class PannsIndex():
             return
         l_child, r_child = None, None
         for attempt in xrange(16):
-            parent.proj = numpy.random.randint(2**32-1)
+            parent.proj = numpy.random.randint(2**32-1, dtype=numpy.uint32)
             u = self.random_direction(parent.proj)
             parent.ofst = self.metric.split(u, children, self.mtx)
             l_child, r_child = [], []


### PR DESCRIPTION
if 'dtype' is not present 'numpy.random.randint(2**32-1, dtype=numpy.uint32)' throws error 'ValueError: high is out of bounds for int32'